### PR TITLE
replace .env with toml configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Secrets*.toml
 Cargo.lock
 enrollments*.json
+config.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
 regex = "1.7.0"
 dotenv = "0.15.0"
 tracing = "0.1.37"
-
-# Database addition shit
 serde = "1.0.188"
 serde_json = "1.0.105"
 google-sheets4 = "5.0.3+20230119"
+toml = "0.8.9"
+serde_derive = "1.0.196"

--- a/src/commands/enrollment.rs
+++ b/src/commands/enrollment.rs
@@ -4,6 +4,7 @@ use serenity::model::prelude::interaction::application_command::{
     CommandDataOption,
     CommandDataOptionValue,
 };
+use crate::{get_config, get_roles};
 
 // private function to unwrap the data option
 fn unwrap_data_option(option_value: &CommandDataOptionValue) -> Option<String> {
@@ -121,10 +122,17 @@ pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicatio
                 .name("student_uni")
                 .description("Which college are you with?")
                 .kind(CommandOptionType::String)
-                .required(true)
-                .add_string_choice("uni_one", "uni_one")
-                .add_string_choice("uni_two", "uni_two")
-                .add_string_choice("Other or N/A", "Other / N/A")
+                .required(true);
+            // get the other roles in the configuration
+            let config = get_config().expect("using config.toml gave an error");
+            let roles = get_roles(&config);
+            // add the choices for those roles
+            for role in roles {
+                student_uni.add_string_choice(role.clone(), role);
+            }
+            // add other choice
+            student_uni.add_string_choice("Other or N/A", "Other / N/A");
+            student_uni
         })
         
         // create email distro sub option

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,9 @@ use serenity::async_trait;
 use serenity::model::gateway::Ready;
 use serenity::model::channel::Message;
 use backend::database_storage::Enrollment;
-use serenity::model::id::{ChannelId, GuildId, RoleId};
+use serenity::model::id::{ChannelId, GuildId};
 use serenity::model::application::interaction::{Interaction, InteractionResponseType};
-use std::ffi::OsStr;
-use std::str::FromStr;
 use serde_derive::Deserialize;
-use tokio::fs;
 use toml::de::Error;
 
 struct Bot;
@@ -27,11 +24,6 @@ struct Data {
     guild: HashMap<String, u64>,
     roles: HashMap<String, u64>,
     channels: HashMap<String, u64>,
-}
-
-// parses environment variables T that meet the trait bounds into K which need to also meet the trait bounds
-fn parse_env<T, K: FromStr>(var: &T) -> K where T: AsRef<OsStr> + std::fmt::Debug + Sized  {
-    dotenv::var(var).unwrap().parse().unwrap_or_else(|_| panic!("{:?} not found / not integer", var))
 }
 
 // takes in a mutable iterator of string literals '
@@ -45,9 +37,16 @@ fn parse_response<'a>(responses: &mut dyn Iterator<Item = &'a str>) -> &'a str {
         .trim_matches('"')
 }
 
-async fn get_config() -> Result<Data, Error> {
-    let data = fs::read_to_string("config.toml").await.unwrap();
+fn get_config() -> Result<Data, Error> {
+   let data = std::fs::read_to_string("config.toml").unwrap();
     toml::from_str(&data)
+}
+
+fn get_roles(config: &Data) -> Vec<String> {
+    config.roles.keys()
+        .filter(|key| key.as_str() != REMOVE_ROLE_ID)
+        .map(|value| value.to_owned() )
+        .collect::<Vec<String>>()
 }
 
 // const env vars
@@ -56,8 +55,6 @@ const READING_CHANNEL_ID: &str = "READING_CHANNEL_ID";
 const ENROLL_CHANNEL_ID: &str = "ENROLL_CHANNEL_ID";
 const GUILD_ID: &str = "GUILD_ID";
 const DISCORD_TOKEN: &str = "discord_token";
-const UNI_ONE_ID: &str = "uni_one_ID";
-const UNI_TWO_ID: &str = "uni_two_ID";
 const REMOVE_ROLE_ID: &str = "REMOVE_ROLE_ID";
 
 #[async_trait]
@@ -73,10 +70,12 @@ impl EventHandler for Bot {
             return
         }
 
+        let config = get_config().expect("using config.toml gave an error");
+
         // pull Channel Id environment vars from .env file
-        let destin_channel = ChannelId(parse_env(&DESTIN_CHANNEL_ID));
-        let reading_channel = ChannelId(parse_env(&READING_CHANNEL_ID));
-        let enroll_channel = ChannelId(parse_env(&ENROLL_CHANNEL_ID));
+        let destin_channel = ChannelId(*config.channels.get(DESTIN_CHANNEL_ID).expect("destin channel id not found"));
+        let reading_channel = ChannelId(*config.channels.get(READING_CHANNEL_ID).expect("reading channel id not found"));
+        let enroll_channel = ChannelId(*config.channels.get(ENROLL_CHANNEL_ID).expect("enroll channel id not found"));
 
 
         // set regular expression patterns for matching messages
@@ -106,9 +105,8 @@ impl EventHandler for Bot {
             let guild_id = msg.guild_id.unwrap();
 
             // pull env vars
-            let uni_one_id = RoleId(parse_env(&UNI_ONE_ID));
-            let uni_two_id = RoleId(parse_env(&UNI_TWO_ID));
-            let remove_id = RoleId(parse_env(&REMOVE_ROLE_ID));
+            let roles = get_roles(&config);
+            let remove_id = *config.roles.get(REMOVE_ROLE_ID).expect("Unable to find remove_id in config.toml");
 
             // Pull student responses from enrollment message
             // skips the first element in response iterator
@@ -120,20 +118,15 @@ impl EventHandler for Bot {
             let distro_response = parse_response(&mut response);
 
             // remove entry point role if uni_response matches "uni_one" or "uni_two"
-            if let "uni_one" | "uni_two" = uni_response {
-                if let Err(e) = guild_id.member(&ctx.http, user_id).await.unwrap().remove_role(&ctx.http, remove_id).await {
-                    error!("Error removing role: {:?}", e);
-                }
-
-                // add university student roles
-                if uni_response == "uni_one" {
-                    if let Err(e) = guild_id.member(&ctx.http, user_id).await.unwrap().add_role(&ctx.http, uni_one_id).await {
+            for role in roles {
+                if role == uni_response {
+                    if let Err(e) = guild_id.member(&ctx.http, user_id).await.unwrap().remove_role(&ctx.http, remove_id).await {
+                        error!("Error removing role: {:?}", e);
+                    }
+                    if let Err(e) = guild_id.member(&ctx.http, user_id).await.unwrap().add_role(&ctx.http, *config.roles.get(&role).expect("Unable to find role")).await {
                         error!("Error adding role: {:?}", e);
                     }
-                } else if uni_response == "uni_two" {
-                    if let Err(e) = guild_id.member(&ctx.http, user_id).await.unwrap().add_role(&ctx.http, uni_two_id).await {
-                        error!("Error adding role: {:?}", e);
-                    }
+                    break
                 }
             }
 
@@ -174,7 +167,8 @@ impl EventHandler for Bot {
         println!("{} is connected!", ready.user.name);
 
         // pull guild ID (discord server ID)
-        let guild_id = GuildId(parse_env(&GUILD_ID));
+        let config = get_config().expect("using config.toml gave an error");
+        let guild_id = GuildId(*config.guild.get(GUILD_ID).expect("Unable to find GUILD_ID in config.toml"));
 
         // create commands for given guild
         let commands = GuildId::set_application_commands(&guild_id, &ctx.http, |commands| {
@@ -220,8 +214,8 @@ impl EventHandler for Bot {
 #[tokio::main]
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
-    let config = get_config().await.expect("using config.toml gave an error");
-    let token: &String = &config.token[DISCORD_TOKEN];
+    let config = get_config().expect("using config.toml gave an error");
+    let token: &String = config.token.get(DISCORD_TOKEN).expect("Unable to find DISCORD_TOKEN in config.toml");
 
     // Set gateway intents, which decides what events the bot will be notified about
     let intents = GatewayIntents::GUILD_MESSAGES | GatewayIntents::MESSAGE_CONTENT |

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod commands;
 mod backend;
 
-use dotenv;
+
 use regex::Regex;
 use tracing::error;
 use serde_json::json;
@@ -103,13 +103,13 @@ impl EventHandler for Bot {
 
         // set regular expression patterns for matching messages
         let http_match = Regex::new(r"^(https|http|\^\^).*").unwrap();
-        let enroll_match = Regex::new(r"^Enrolling new student\:").unwrap();
+        let enroll_match = Regex::new(r"^Enrolling new student:").unwrap();
 
         // if the message is in the reading channel and matches the http regex, 
         // send it to the destin channel
         if msg.channel_id == reading_channel {
             if http_match.is_match(&msg.content) && !msg.author.bot {
-                
+
                 // Make a prettier message with the original authors name to send
                 let message = format!(".\n*This was originally posted by `{}`:*\n{}", msg.author.name, msg.content);
 
@@ -123,14 +123,14 @@ impl EventHandler for Bot {
         // if the message is in the enrollment channel and matches the enrollment regex,
         // add the student role, remove the entry point role, and change the user's nickname
         if msg.channel_id == enroll_channel {
-            
+
             if enroll_match.is_match(&msg.content) && msg.author.bot {
 
                 // pull user and guild IDs from the message
                 let user_id = msg.interaction.as_ref().unwrap().user.id;
                 let user_name = msg.interaction.unwrap().user.name;
                 let guild_id = msg.guild_id.unwrap();
-                
+
                 // pull env vars
                 let uni_one_id = RoleId(
                     dotenv::var("uni_one_ID")
@@ -150,7 +150,7 @@ impl EventHandler for Bot {
                         .parse::<u64>()
                         .expect("Remove Role ID Var not found"),
                 );
-                
+
                 // Pull student responses from enrollment message
                 let nickname = msg.content
                     .split("\n")
@@ -223,7 +223,7 @@ impl EventHandler for Bot {
                 });
 
                 let user_data: Enrollment = serde_json::from_value(user_data_json).unwrap();
-                
+
                 if let Err(e) = backend::database_storage::save_to_json(&user_data) {
                     error!("Error saving to json: {:?}", e);
                 }


### PR DESCRIPTION
Allows for role names to be given by the configuration rather than hardcoded